### PR TITLE
Support lnd caveats in lnchat macaroon

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -45,7 +45,8 @@ func initCliFlags() {
 	// APP flags
 	rootFlags.Int64("default-fee-limit-msat", 3000,
 		"Default fee limit for discussions in millisatoshi")
-	_ = viper.BindPFlag("app.default_fee_limit_msat", rootFlags.Lookup("default-fee-limit-msat"))
+	_ = viper.BindPFlag("app.default_fee_limit_msat",
+		rootFlags.Lookup("default-fee-limit-msat"))
 
 	// RPC flags
 	rootFlags.String("server-address", "localhost:9999",
@@ -69,7 +70,8 @@ func initCliFlags() {
 	_ = viper.BindPFlag("server.rpcpass", rootFlags.Lookup("server-pass"))
 	rootFlags.Int("graceful-shutdown-timeout", 10,
 		"Graceful shutdown timeout in seconds")
-	_ = viper.BindPFlag("server.graceful_shutdown_timeout", rootFlags.Lookup("graceful-shutdown-timeout"))
+	_ = viper.BindPFlag("server.graceful_shutdown_timeout",
+		rootFlags.Lookup("graceful-shutdown-timeout"))
 
 	// LND flags
 	rootFlags.String("lnd-address", "localhost:10009",
@@ -83,6 +85,13 @@ func initCliFlags() {
 	_ = viper.BindPFlag("lnd.macaroon_path", rootFlags.Lookup("lnd-macaroon-path"))
 	rootFlags.StringVarP(&lndConnectURL, "lndconnect", "l", "",
 		"lndconnect URL to use for connection to the Lightning daemon")
+	rootFlags.Int64("lnd-macaroon-timeout", 0,
+		"Lifetime of transmitted daemon macaroon in seconds")
+	_ = viper.BindPFlag("lnd.macaroon_timeout_secs",
+		rootFlags.Lookup("lnd-macaroon-timeout"))
+	rootFlags.String("lnd-macaroon-ip", "",
+		"IP to lock the transmitted daemon macaroon to")
+	_ = viper.BindPFlag("lnd.macaroon_ip", rootFlags.Lookup("lnd-macaroon-ip"))
 
 	// DB flags
 	rootFlags.String("db-path", "c13n.db",

--- a/cli/cmd/root_run.go
+++ b/cli/cmd/root_run.go
@@ -67,16 +67,19 @@ func Run(_ *cobra.Command, _ []string) error {
 	}
 
 	// Initialize chat service
+	macConstraints := lnchat.MacaroonConstraints{}
 	var creds lnconnect.Credentials
 	if viper.GetString("lndconnect") != "" {
 		creds, err = lnchat.NewCredentialsFromURL(
 			viper.GetString("lndconnect"),
+			macConstraints,
 		)
 	} else {
 		creds, err = lnchat.NewCredentials(
 			viper.GetString("lnd.address"),
 			viper.GetString("lnd.tls_path"),
 			viper.GetString("lnd.macaroon_path"),
+			macConstraints,
 		)
 	}
 	if err != nil {

--- a/cli/cmd/root_run.go
+++ b/cli/cmd/root_run.go
@@ -67,8 +67,13 @@ func Run(_ *cobra.Command, _ []string) error {
 	}
 
 	// Initialize chat service
-	macConstraints := lnchat.MacaroonConstraints{}
 	var creds lnconnect.Credentials
+
+	macConstraints := lnchat.MacaroonConstraints{
+		Timeout: viper.GetInt64("lnd.macaroon_timeout_secs"),
+		IPLock:  viper.GetString("lnd.macaroon_ip"),
+	}
+
 	if viper.GetString("lndconnect") != "" {
 		creds, err = lnchat.NewCredentialsFromURL(
 			viper.GetString("lndconnect"),

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -15,6 +15,8 @@ lnd:
   address: "localhost:10009"
   tls_path: "~/.lnd/tls.cert"
   macaroon_path: "~/.lnd/data/chain/bitcoin/regtest/admin.macaroon"
+  macaroon_timeout_secs: 0
+  macaroon_ip: ""
 # Application configuration
 app:
   default_fee_limit_msat: 3000

--- a/lnchat/creds.go
+++ b/lnchat/creds.go
@@ -15,7 +15,9 @@ import (
 
 // NewCredentials constructs a set of credentials
 // from the address and the TLS and macaroon file paths.
-func NewCredentials(rpcAddr, tlsPath, macPath string) (lnconnect.Credentials, error) {
+func NewCredentials(rpcAddr, tlsPath, macPath string,
+	macConstraints MacaroonConstraints) (lnconnect.Credentials, error) {
+
 	creds := lnconnect.Credentials{
 		RPCAddress: rpcAddr,
 	}
@@ -36,7 +38,8 @@ func NewCredentials(rpcAddr, tlsPath, macPath string) (lnconnect.Credentials, er
 		}
 
 		creds.RPCCreds = macaroonCredentials{
-			Macaroon: mac,
+			Macaroon:    mac,
+			constraints: macConstraints,
 		}
 	}
 
@@ -45,7 +48,8 @@ func NewCredentials(rpcAddr, tlsPath, macPath string) (lnconnect.Credentials, er
 
 // NewCredentialsFromURL constructs a set of credentials
 // from an lndconnect URL.
-func NewCredentialsFromURL(lndConnectURL string) (lnconnect.Credentials, error) {
+func NewCredentialsFromURL(lndConnectURL string,
+	macConstraints MacaroonConstraints) (lnconnect.Credentials, error) {
 	creds := lnconnect.Credentials{}
 
 	addr, tlsBytes, macBytes, err := parseLNDConnectURL(lndConnectURL)
@@ -70,7 +74,8 @@ func NewCredentialsFromURL(lndConnectURL string) (lnconnect.Credentials, error) 
 		return creds, errors.Wrap(err, "could not load macaroon")
 	}
 	creds.RPCCreds = macaroonCredentials{
-		Macaroon: mac,
+		Macaroon:    mac,
+		constraints: macConstraints,
 	}
 
 	return creds, nil

--- a/lnchat/creds.go
+++ b/lnchat/creds.go
@@ -1,12 +1,14 @@
 package lnchat
 
 import (
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
 	"io/ioutil"
 	"net/url"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/c13n-io/c13n-go/lnchat/lnconnect"
 )
@@ -20,11 +22,12 @@ func NewCredentials(rpcAddr, tlsPath, macPath string) (lnconnect.Credentials, er
 
 	var err error
 	if tlsPath != "" {
-		creds.TLSBytes, err = loadTLSFile(tlsPath)
+		creds.TLSCreds, err = loadTLSCreds(tlsPath)
 		if err != nil {
 			return creds, errors.Wrap(err, "could not read TLS file")
 		}
 	}
+
 	if macPath != "" {
 		creds.MacaroonBytes, err = loadMacFile(macPath)
 		if err != nil {
@@ -39,26 +42,6 @@ func NewCredentials(rpcAddr, tlsPath, macPath string) (lnconnect.Credentials, er
 // from an lndconnect URL.
 func NewCredentialsFromURL(lndConnectURL string) (lnconnect.Credentials, error) {
 	return parseLNDConnectURL(lndConnectURL)
-}
-
-func loadTLSFile(tlsPath string) ([]byte, error) {
-	tlsBytes, err := ioutil.ReadFile(tlsPath)
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(tlsBytes)
-	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, errors.New("certificate block not found")
-	}
-
-	return block.Bytes, nil
-}
-
-func loadMacFile(macaroonPath string) ([]byte, error) {
-	macBytes, err := ioutil.ReadFile(macaroonPath)
-
-	return macBytes, err
 }
 
 func parseLNDConnectURL(lndConnectURL string) (lnconnect.Credentials, error) {
@@ -83,9 +66,18 @@ func parseLNDConnectURL(lndConnectURL string) (lnconnect.Credentials, error) {
 		if !ok || len(cert) != 1 || cert[0] == "" {
 			return creds, errors.New("TLS certificate must be present in lndconnect URL")
 		}
-		creds.TLSBytes, err = decoder.DecodeString(cert[0])
+		tlsBytes, err := decoder.DecodeString(cert[0])
 		if err != nil {
 			return creds, errors.Wrap(err, "could not decode TLS bytes")
+		}
+		creds.TLSCreds, err = loadTLSCredsFromBytes(
+			pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: tlsBytes,
+			}),
+		)
+		if err != nil {
+			return creds, err
 		}
 
 		mac, ok := queryMap["macaroon"]
@@ -99,4 +91,28 @@ func parseLNDConnectURL(lndConnectURL string) (lnconnect.Credentials, error) {
 	}
 
 	return creds, nil
+}
+
+func loadTLSCreds(tlsPath string) (credentials.TransportCredentials, error) {
+	certBytes, err := ioutil.ReadFile(tlsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return loadTLSCredsFromBytes(certBytes)
+}
+
+func loadTLSCredsFromBytes(certBytes []byte) (credentials.TransportCredentials, error) {
+	tlsCertPool := x509.NewCertPool()
+	if !tlsCertPool.AppendCertsFromPEM(certBytes) {
+		return nil, errors.New("failed to append certificate")
+	}
+
+	return credentials.NewClientTLSFromCert(tlsCertPool, ""), nil
+}
+
+func loadMacFile(macaroonPath string) ([]byte, error) {
+	macBytes, err := ioutil.ReadFile(macaroonPath)
+
+	return macBytes, err
 }

--- a/lnchat/creds.go
+++ b/lnchat/creds.go
@@ -20,18 +20,23 @@ func NewCredentials(rpcAddr, tlsPath, macPath string) (lnconnect.Credentials, er
 		RPCAddress: rpcAddr,
 	}
 
-	var err error
 	if tlsPath != "" {
-		creds.TLSCreds, err = loadTLSCreds(tlsPath)
+		tlsCreds, err := loadTLSCreds(tlsPath)
 		if err != nil {
-			return creds, errors.Wrap(err, "could not read TLS file")
+			return creds, errors.Wrap(err, "could not load TLS certificate")
 		}
+
+		creds.TLSCreds = tlsCreds
 	}
 
 	if macPath != "" {
-		creds.MacaroonBytes, err = loadMacFile(macPath)
+		mac, err := loadMacaroon(macPath)
 		if err != nil {
-			return creds, errors.Wrap(err, "could not read macaroon file")
+			return creds, errors.Wrap(err, "could not load macaroon")
+		}
+
+		creds.RPCCreds = macaroonCredentials{
+			Macaroon: mac,
 		}
 	}
 
@@ -41,56 +46,88 @@ func NewCredentials(rpcAddr, tlsPath, macPath string) (lnconnect.Credentials, er
 // NewCredentialsFromURL constructs a set of credentials
 // from an lndconnect URL.
 func NewCredentialsFromURL(lndConnectURL string) (lnconnect.Credentials, error) {
-	return parseLNDConnectURL(lndConnectURL)
-}
+	creds := lnconnect.Credentials{}
 
-func parseLNDConnectURL(lndConnectURL string) (lnconnect.Credentials, error) {
-	var creds lnconnect.Credentials
+	addr, tlsBytes, macBytes, err := parseLNDConnectURL(lndConnectURL)
+	if err != nil {
+		return creds, err
+	}
+	creds.RPCAddress = addr
 
-	if lndConnectURL != "" {
-		lndURL, err := url.Parse(lndConnectURL)
-		if err != nil {
-			return creds, errors.Wrap(err, "could not parse lndconnect URL")
-		}
-		if lndURL.Scheme != "lndconnect" {
-			return creds, errors.New("invalid scheme for lndconnect URL")
-		}
+	tlsCreds, err := loadTLSCredsFromBytes(
+		pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: tlsBytes,
+		}),
+	)
+	if err != nil {
+		return creds, errors.Wrap(err, "could not load TLS certificate")
+	}
+	creds.TLSCreds = tlsCreds
 
-		creds.RPCAddress = lndURL.Host
-
-		queryMap := lndURL.Query()
-		decoder := base64.RawURLEncoding
-
-		// If the query map does not contain a cert key or it's empty, error out.
-		cert, ok := queryMap["cert"]
-		if !ok || len(cert) != 1 || cert[0] == "" {
-			return creds, errors.New("TLS certificate must be present in lndconnect URL")
-		}
-		tlsBytes, err := decoder.DecodeString(cert[0])
-		if err != nil {
-			return creds, errors.Wrap(err, "could not decode TLS bytes")
-		}
-		creds.TLSCreds, err = loadTLSCredsFromBytes(
-			pem.EncodeToMemory(&pem.Block{
-				Type:  "CERTIFICATE",
-				Bytes: tlsBytes,
-			}),
-		)
-		if err != nil {
-			return creds, err
-		}
-
-		mac, ok := queryMap["macaroon"]
-		if !ok || len(mac) != 1 || mac[0] == "" {
-			return creds, errors.New("macaroon must be present in lndconnect URL")
-		}
-		creds.MacaroonBytes, err = decoder.DecodeString(mac[0])
-		if err != nil {
-			return creds, errors.Wrap(err, "could not decode macaroon bytes")
-		}
+	mac, err := loadMacaroonFromBytes(macBytes)
+	if err != nil {
+		return creds, errors.Wrap(err, "could not load macaroon")
+	}
+	creds.RPCCreds = macaroonCredentials{
+		Macaroon: mac,
 	}
 
 	return creds, nil
+}
+
+func parseLNDConnectURL(lndConnectURL string) (string, []byte, []byte, error) {
+	decoder := base64.RawURLEncoding
+	// Retrieve and decode an attribute (base64URL-encoded) from a url query.
+	getDecodedAttrValue := func(values url.Values, key string) ([]byte, error) {
+		val := values.Get(key)
+		decodedVal, err := decoder.DecodeString(val)
+		if err != nil {
+			return nil, err
+		}
+
+		return decodedVal, nil
+	}
+
+	var addr string
+	var tlsBytes, macBytes []byte
+	var err error
+	if lndConnectURL != "" {
+		lndURL, err := url.Parse(lndConnectURL)
+		if err != nil {
+			return "", nil, nil,
+				errors.Wrap(err, "could not parse lndconnect URL")
+		}
+		if lndURL.Scheme != "lndconnect" {
+			return "", nil, nil,
+				errors.New("invalid scheme for lndconnect URL")
+		}
+
+		addr = lndURL.Host
+		attrMap := lndURL.Query()
+
+		tlsBytes, err = getDecodedAttrValue(attrMap, "cert")
+		if err != nil {
+			return addr, nil, nil,
+				errors.Wrap(err, "could not decode certificate")
+		}
+		if len(tlsBytes) == 0 {
+			return addr, nil, nil,
+				errors.New("lndconnect URL missing cert value")
+		}
+
+		macBytes, err = getDecodedAttrValue(attrMap, "macaroon")
+		if err != nil {
+			return addr, tlsBytes, nil,
+				errors.Wrap(err, "could not decode macaroon")
+		}
+		if len(macBytes) == 0 {
+			return addr, tlsBytes, nil,
+				errors.New("lndconnect URL missing macaroon value")
+		}
+	}
+
+	return addr, tlsBytes, macBytes, err
 }
 
 func loadTLSCreds(tlsPath string) (credentials.TransportCredentials, error) {
@@ -109,10 +146,4 @@ func loadTLSCredsFromBytes(certBytes []byte) (credentials.TransportCredentials, 
 	}
 
 	return credentials.NewClientTLSFromCert(tlsCertPool, ""), nil
-}
-
-func loadMacFile(macaroonPath string) ([]byte, error) {
-	macBytes, err := ioutil.ReadFile(macaroonPath)
-
-	return macBytes, err
 }

--- a/lnchat/creds_test.go
+++ b/lnchat/creds_test.go
@@ -101,6 +101,7 @@ func TestNewCredentials(t *testing.T) {
 		name                      string
 		rpcAddr, tlsPath, macPath string
 		lndConnectURL             string
+		macConstraints            MacaroonConstraints
 		expectedCreds             lnconnect.Credentials
 		expectedErr               error
 	}{
@@ -163,9 +164,11 @@ func TestNewCredentials(t *testing.T) {
 
 			switch c.lndConnectURL {
 			case "":
-				creds, err = NewCredentials(c.rpcAddr, c.tlsPath, c.macPath)
+				creds, err = NewCredentials(c.rpcAddr, c.tlsPath,
+					c.macPath, c.macConstraints)
 			default:
-				creds, err = NewCredentialsFromURL(c.lndConnectURL)
+				creds, err = NewCredentialsFromURL(c.lndConnectURL,
+					c.macConstraints)
 			}
 
 			if c.expectedErr != nil {

--- a/lnchat/creds_test.go
+++ b/lnchat/creds_test.go
@@ -2,6 +2,7 @@ package lnchat
 
 import (
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,24 +11,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/c13n-io/c13n-go/lnchat/lnconnect"
 )
 
 var (
-	certContents = `-----BEGIN CERTIFICATE-----
-MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
-DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
-EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
-7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
-5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
-BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
-NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
-Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
-6MF9+Yw1Yy0t
------END CERTIFICATE-----`
+	lndHost = "127.0.0.1:10009"
 
-	certBody = "" +
+	// TLS certificate body encoded as base64URL
+	certBodyEnc = "" +
 		"MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn-dNuaTAKBggqhkjOPQQDAjASMRAw" +
 		"DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow" +
 		"EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d" +
@@ -38,7 +31,8 @@ Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
 		"Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h_iI-i341gBmLiAFQOyTDT-_wQc" +
 		"6MF9-Yw1Yy0t"
 
-	macEncBase64 = "" +
+	// Macaroon bytes encoded as base64URL
+	macBytesEnc = "" +
 		"AgEDbG5kAvgBAwoQ0SfUsCGDIr9Q7AtZyDs3YhIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoT" +
 		"CgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaIQoIbWFjYXJvb24S" +
 		"CGdlbmVyYXRlEgRyZWFkEgV3cml0ZRoWCgdtZXNzYWdlEgRyZWFkEgV3cml0ZRoXCghvZmZjaGFp" +
@@ -63,7 +57,7 @@ func TestNewCredentials(t *testing.T) {
 		return url
 	}
 
-	mustDecodeBase64 := func(t *testing.T, enc string) []byte {
+	mustDecodeBase64URL := func(t *testing.T, enc string) []byte {
 		decoder := base64.RawURLEncoding
 
 		bytes, err := decoder.DecodeString(enc)
@@ -72,18 +66,25 @@ func TestNewCredentials(t *testing.T) {
 		return bytes
 	}
 
-	lndHost := "127.0.0.1:10009"
-
-	tlsBytes := mustDecodeBase64(t, certBody)
-	macBytes := mustDecodeBase64(t, macEncBase64)
+	// Recreate certificate and write to file.
+	certBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: mustDecodeBase64URL(t, certBodyEnc),
+	})
 
 	tempCertPath := filepath.Join(os.TempDir(), "test_tls.cert")
-	_ = ioutil.WriteFile(tempCertPath, []byte(certContents), 0644)
+	_ = ioutil.WriteFile(tempCertPath, certBytes, 0644)
 	defer os.Remove(tempCertPath)
+
+	// Write decoded macaroon to file.
+	macBytes := mustDecodeBase64URL(t, macBytesEnc)
 
 	tempMacPath := filepath.Join(os.TempDir(), "test_mac.macaroon")
 	_ = ioutil.WriteFile(tempMacPath, macBytes, 0644)
 	defer os.Remove(tempMacPath)
+
+	expectedTLSCreds, err := credentials.NewClientTLSFromFile(tempCertPath, "")
+	require.NoError(t, err)
 
 	cases := []struct {
 		name                      string
@@ -94,22 +95,22 @@ func TestNewCredentials(t *testing.T) {
 	}{
 		{
 			name:          "lndconnect credentials without macaroon parameter",
-			lndConnectURL: createURL(lndHost, certBody, ""),
+			lndConnectURL: createURL(lndHost, certBodyEnc, ""),
 			expectedCreds: lnconnect.Credentials{},
 			expectedErr:   fmt.Errorf("macaroon must be present in lndconnect URL"),
 		},
 		{
-			name:          "lndconnect credentials without cert parameter",
-			lndConnectURL: createURL(lndHost, "", macEncBase64),
+			name:          "lndconnect credentials without certificate",
+			lndConnectURL: createURL(lndHost, "", macBytesEnc),
 			expectedCreds: lnconnect.Credentials{},
 			expectedErr:   fmt.Errorf("TLS certificate must be present in lndconnect URL"),
 		},
 		{
 			name:          "lndconnect credentials",
-			lndConnectURL: createURL(lndHost, certBody, macEncBase64),
+			lndConnectURL: createURL(lndHost, certBodyEnc, macBytesEnc),
 			expectedCreds: lnconnect.Credentials{
 				RPCAddress:    lndHost,
-				TLSBytes:      tlsBytes,
+				TLSCreds:      expectedTLSCreds,
 				MacaroonBytes: macBytes,
 			},
 		},
@@ -119,7 +120,7 @@ func TestNewCredentials(t *testing.T) {
 			tlsPath: tempCertPath,
 			expectedCreds: lnconnect.Credentials{
 				RPCAddress: lndHost,
-				TLSBytes:   tlsBytes,
+				TLSCreds:   expectedTLSCreds,
 			},
 		},
 		{
@@ -138,7 +139,7 @@ func TestNewCredentials(t *testing.T) {
 			macPath: tempMacPath,
 			expectedCreds: lnconnect.Credentials{
 				RPCAddress:    lndHost,
-				TLSBytes:      tlsBytes,
+				TLSCreds:      expectedTLSCreds,
 				MacaroonBytes: macBytes,
 			},
 		},
@@ -156,14 +157,20 @@ func TestNewCredentials(t *testing.T) {
 				creds, err = NewCredentialsFromURL(c.lndConnectURL)
 			}
 
-			switch c.expectedErr {
-			case nil:
-				assert.NoError(t, err)
-				assert.NotEmpty(t, creds)
-				assert.EqualValues(t, c.expectedCreds, creds)
-			default:
+			if c.expectedErr != nil {
 				assert.EqualError(t, err, c.expectedErr.Error())
+				return
 			}
+
+			assert.NoError(t, err)
+
+			assert.EqualValues(t,
+				c.expectedCreds.RPCAddress, creds.RPCAddress)
+			if c.expectedCreds.TLSCreds != nil {
+				assert.NotEmpty(t, creds.TLSCreds)
+			}
+			assert.EqualValues(t,
+				c.expectedCreds.MacaroonBytes, creds.MacaroonBytes)
 		})
 	}
 }

--- a/lnchat/lnconnect/lnconnect.go
+++ b/lnchat/lnconnect/lnconnect.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	macaroon "gopkg.in/macaroon.v2"
 )
 
 // ErrCredentials represents a credentials error.
@@ -17,9 +15,9 @@ var ErrCredentials = fmt.Errorf("credentials error")
 // Credentials is used to pass identification and connection
 // parameters to InitializeConnection.
 type Credentials struct {
-	RPCAddress    string
-	TLSCreds      credentials.TransportCredentials
-	MacaroonBytes []byte
+	RPCAddress string
+	TLSCreds   credentials.TransportCredentials
+	RPCCreds   credentials.PerRPCCredentials
 }
 
 var (
@@ -34,34 +32,14 @@ func InitializeConnection(cfg Credentials) (*grpc.ClientConn, error) {
 		return nil, fmt.Errorf("%w: TLS certificate not provided", ErrCredentials)
 	}
 
-	mac := &macaroon.Macaroon{}
-	if err := mac.UnmarshalBinary(cfg.MacaroonBytes); err != nil {
-		return nil, fmt.Errorf("%w: could not unmarshal macaroon: %v", ErrCredentials, err)
-	}
-
-	// Use a constrained macaroon for RPC calls
-	macConstraints := []macaroons.Constraint{
-		// Lock macaroon to our IP address (empty string means no caveat)
-		macaroons.IPLockConstraint(""),
-		// Define macaroon timeout in seconds (max-int64 overflows?)
-		macaroons.TimeoutConstraint(1 << 32),
-	}
-	constrMac, err := macaroons.AddConstraints(mac, macConstraints...)
-	if err != nil {
-		return nil, fmt.Errorf("%w: could not add macaroon constraints: %v",
-			ErrCredentials, err)
-	}
-	perRPCCreds, err := macaroons.NewMacaroonCredential(constrMac)
-	if err != nil {
-		return nil, fmt.Errorf("%w: could not create per-RPC credentials: %v",
-			ErrCredentials, err)
-	}
-
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(cfg.TLSCreds),
-		grpc.WithPerRPCCredentials(perRPCCreds),
 		grpc.WithBlock(),
 		grpc.WithDefaultCallOptions(maxMsgRecvSize),
+	}
+
+	if cfg.RPCCreds != nil {
+		opts = append(opts, grpc.WithPerRPCCredentials(cfg.RPCCreds))
 	}
 
 	// Set a timeout for the blocking connection call

--- a/lnchat/macaroon.go
+++ b/lnchat/macaroon.go
@@ -16,6 +16,7 @@ import (
 type MacaroonConstraints struct {
 	// Timeout restricts the lifetime of
 	// the transmitted macaroon (in seconds).
+	// A value of 0 (default) does not set a timeout caveat.
 	Timeout int64
 	// IPLock locks the transmitted macaroon to an IP address.
 	// Empty value is ignored.

--- a/lnchat/macaroon.go
+++ b/lnchat/macaroon.go
@@ -1,0 +1,56 @@
+package lnchat
+
+import (
+	"context"
+	"encoding/hex"
+	"io/ioutil"
+
+	"google.golang.org/grpc/credentials"
+	macaroon "gopkg.in/macaroon.v2"
+)
+
+// macaroonCredentials implements grpc/credentials.PerRPCCredentials interface.
+type macaroonCredentials struct {
+	*macaroon.Macaroon
+}
+
+func (mc macaroonCredentials) RequireTransportSecurity() bool {
+	return true
+}
+
+func (mc macaroonCredentials) GetRequestMetadata(_ context.Context,
+	_ ...string) (map[string]string, error) {
+
+	macBytes, err := mc.Macaroon.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	md := make(map[string]string)
+	md["macaroon"] = hex.EncodeToString(macBytes)
+
+	return md, nil
+}
+
+// Compile-time assertion to ensure macaroonCredentials
+// implements credentials.PerRPCCredentials interface.
+var _ credentials.PerRPCCredentials = macaroonCredentials{}
+
+func loadMacaroon(macPath string) (*macaroon.Macaroon, error) {
+	macBytes, err := ioutil.ReadFile(macPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return loadMacaroonFromBytes(macBytes)
+}
+
+func loadMacaroonFromBytes(macBytes []byte) (*macaroon.Macaroon, error) {
+	mac := &macaroon.Macaroon{}
+
+	if err := mac.UnmarshalBinary(macBytes); err != nil {
+		return nil, err
+	}
+
+	return mac, nil
+}

--- a/lnchat/tests/create_manager_test.go
+++ b/lnchat/tests/create_manager_test.go
@@ -9,10 +9,12 @@ import (
 )
 
 func testNewLnchat(net *lntest.NetworkHarness, t *harnessTest) {
+	constraints := lnchat.MacaroonConstraints{}
 	creds, err := lnchat.NewCredentials(
 		net.Alice.Cfg.RPCAddr(),
 		net.Alice.TLSCertStr(),
 		net.Alice.AdminMacPath(),
+		constraints,
 	)
 	require.NoError(t.t, err)
 

--- a/lnchat/tests/lnchat_helper.go
+++ b/lnchat/tests/lnchat_helper.go
@@ -7,10 +7,13 @@ import (
 )
 
 func createNodeManager(node *lntest.HarnessNode) (lnchat.LightManager, error) {
+	constraints := lnchat.MacaroonConstraints{}
+
 	creds, err := lnchat.NewCredentials(
 		node.Cfg.RPCAddr(),
 		node.TLSCertStr(),
 		node.AdminMacPath(),
+		constraints,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This MR implements support for addition of first-party caveats (timeout, ip lock) on transmitted macaroon on `lnd` connection credentials.