### PR TITLE
Create typed publish-subscribe methods for Message

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -57,7 +57,7 @@ func createInitializedApp(t *testing.T, mockInstaller func(*lnmock.LightManager,
 		err := app.Init(context.Background(), 15)
 
 		require.NoError(t, err)
-		require.NotNil(t, app.PubSubBus)
+		require.NotNil(t, app.bus)
 	}
 	appTestStopFunc := func() {
 		mockStopFunc()
@@ -103,7 +103,7 @@ func TestAppInitSuccess(t *testing.T) {
 	defer appTestStopFunc()
 
 	assert.EqualValues(t, selfInfo, app.Self)
-	assert.NotNil(t, app.PubSubBus)
+	assert.NotNil(t, app.bus)
 }
 
 func TestAppInitErrorSelfInfo(t *testing.T) {
@@ -130,7 +130,7 @@ func TestAppInitErrorSelfInfo(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.EqualError(t, err, expectedErr.Error())
 	}
-	assert.Nil(t, app.PubSubBus)
+	assert.Nil(t, app.bus)
 }
 
 func TestBackoffFn(t *testing.T) {

--- a/app/error.go
+++ b/app/error.go
@@ -13,8 +13,7 @@ type ErrKind int
 
 // Declaration of error kind enumeration.
 const (
-	MarshalError ErrKind = iota
-	Cancelled
+	Cancelled ErrKind = iota
 	DeadlineExceeded
 	NetworkError
 	PermissionError

--- a/app/invoice_subscription_test.go
+++ b/app/invoice_subscription_test.go
@@ -162,7 +162,7 @@ func TestSubscribeInvoices(t *testing.T) {
 		addDiscussionErr         error
 		addRawMsgErr             error
 		addRawMsgID              uint64
-		message                  *model.Message
+		message                  *MaybeMessage
 	}
 
 	cases := []struct {
@@ -196,21 +196,23 @@ func TestSubscribeInvoices(t *testing.T) {
 					addDiscussionErr:         nil,
 					addRawMsgErr:             nil,
 					addRawMsgID:              42,
-					message: &model.Message{
-						ID:             42,
-						DiscussionID:   13,
-						Payload:        "test message",
-						AmtMsat:        124,
-						Sender:         srcAddr.String(),
-						Receiver:       selfAddr.String(),
-						SenderVerified: true,
-						SentTimeNs:     time.Unix(invoiceUpdateList[0].Inv.CreatedTimeSec, 0).UnixNano(),
-						ReceivedTimeNs: time.Unix(invoiceUpdateList[0].Inv.SettleTimeSec, 0).UnixNano(),
-						Index:          invoiceUpdateList[0].Inv.SettleIndex,
-						PayReq:         "dummy payment request",
-						SuccessProb:    1.,
-						PreimageHash:   mustMakePreimageHash(t, invoiceUpdateList[0].Inv.Hash),
-						Preimage:       mustMakePreimage(t, invoiceUpdateList[0].Inv.Preimage),
+					message: &MaybeMessage{
+						Message: &model.Message{
+							ID:             42,
+							DiscussionID:   13,
+							Payload:        "test message",
+							AmtMsat:        124,
+							Sender:         srcAddr.String(),
+							Receiver:       selfAddr.String(),
+							SenderVerified: true,
+							SentTimeNs:     time.Unix(invoiceUpdateList[0].Inv.CreatedTimeSec, 0).UnixNano(),
+							ReceivedTimeNs: time.Unix(invoiceUpdateList[0].Inv.SettleTimeSec, 0).UnixNano(),
+							Index:          invoiceUpdateList[0].Inv.SettleIndex,
+							PayReq:         "dummy payment request",
+							SuccessProb:    1.,
+							PreimageHash:   mustMakePreimageHash(t, invoiceUpdateList[0].Inv.Hash),
+							Preimage:       mustMakePreimage(t, invoiceUpdateList[0].Inv.Preimage),
+						},
 					},
 				},
 			},
@@ -423,13 +425,10 @@ func TestSubscribeInvoices(t *testing.T) {
 					continue
 				}
 
-				pubMsg, ok := <-msgCh
+				maybeMsg, ok := <-msgCh
 				assert.Truef(t, ok, "Expected message %d not received prior to channel close", i)
-				var msg model.Message
-				err := json.Unmarshal(pubMsg.Payload, &msg)
-				assert.NoError(t, err)
 
-				assert.EqualValues(t, c.invoiceUpdateOps[i].message, &msg)
+				assert.EqualValues(t, c.invoiceUpdateOps[i].message, &maybeMsg)
 			}
 		})
 	}

--- a/app/subscription.go
+++ b/app/subscription.go
@@ -10,34 +10,79 @@ import (
 	"github.com/c13n-io/c13n-go/model"
 )
 
-const (
-	// ReceiveTopic is the pubsub topic for received messages.
-	ReceiveTopic = "message.receive"
-)
+type BusError struct {
+	op string
+	e  error
+}
 
-// publishMessage publishes a message.
-func (app *App) publishMessage(msg *model.Message) error {
-	// Marshal message as json for publishing
-	msgBytes, err := json.Marshal(msg)
-	if err != nil {
-		return Error{Kind: MarshalError, details: "publishMessage", Err: err}
+func (be BusError) Error() string {
+	return "bus " + be.op + " error: " + be.e.Error()
+}
+
+func (app *App) publish(topic string, data []byte) error {
+	busMsg := message.NewMessage(watermill.NewUUID(), data)
+	if err := app.bus.Publish(topic, busMsg); err != nil {
+		return BusError{op: "publish", e: err}
 	}
-
-	// Publish message under message topic
-	pubMsg := message.NewMessage(watermill.NewUUID(), msgBytes)
-	if err := app.PubSubBus.Publish(ReceiveTopic, pubMsg); err != nil {
-		return Error{Kind: InternalError, details: "Publish error", Err: err}
-	}
-
 	return nil
 }
 
-// SubscribeMessages returns a channel over which received messages are sent.
-func (app *App) SubscribeMessages(ctx context.Context) (<-chan *message.Message, error) {
-	msgCh, err := app.PubSubBus.Subscribe(ctx, ReceiveTopic)
+func (app *App) subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
+	subCh, err := app.bus.Subscribe(ctx, topic)
 	if err != nil {
-		return msgCh, Error{Kind: InternalError, details: "Subscribe error", Err: err}
+		return subCh, BusError{op: "subscribe", e: err}
 	}
+
+	return subCh, nil
+}
+
+const (
+	// messageTopic is the topic where message events are published.
+	messageTopic = "message"
+)
+
+func (app *App) publishMessage(msg *model.Message) error {
+	// Marshal as json for publishing in bus.
+	msgBytes, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	return app.publish(messageTopic, msgBytes)
+}
+
+type MaybeMessage struct {
+	Message *model.Message
+	Error   error
+}
+
+// SubscribeMessages returns a channel over which received messages are sent.
+// The subscriber is responsible for draining the channel
+// once the subscription terminates.
+func (app *App) SubscribeMessages(ctx context.Context) (<-chan MaybeMessage, error) {
+	subCh, err := app.subscribe(ctx, messageTopic)
+	if err != nil {
+		return nil, err
+	}
+
+	msgCh := make(chan MaybeMessage)
+	go func() {
+		defer close(msgCh)
+
+		// Forward messages until subscriber exits.
+		for subMsg := range subCh {
+			subMsg.Ack()
+
+			// Unmarshal message data in a fresh variable.
+			msg := new(model.Message)
+			err := json.Unmarshal(subMsg.Payload, msg)
+
+			msgCh <- MaybeMessage{
+				Message: msg,
+				Error:   err,
+			}
+		}
+	}()
 
 	return msgCh, nil
 }

--- a/app/subscription_test.go
+++ b/app/subscription_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestTopicConsts(t *testing.T) {
-	assert.EqualValues(t, "message.receive", ReceiveTopic)
+	assert.EqualValues(t, "message", messageTopic)
 }


### PR DESCRIPTION
This MR moves the marshalling-unmarshalling of messages sent over [pubsub](https://pkg.go.dev/github.com/ThreeDotsLabs/watermill@v1.1.1/pubsub/gochannel) inside the relevant subscription method, returning a tuple on the returned channel.