### PR TITLE
Use pattern pinning

### DIFF
--- a/docker/c13n/Dockerfile
+++ b/docker/c13n/Dockerfile
@@ -1,10 +1,9 @@
 FROM golang:1.17-alpine as builder
 
 # Install dependencies and install/build lnd.
-RUN apk add --no-cache --update alpine-sdk=1.0-r1 \
-    git=2.36.0-r0  \
-    bash=5.1.16-r2  \
-    make=4.3-r0
+RUN apk add --no-cache --update alpine-sdk~=1.0 \
+    bash~=5.1.16  \
+    make~=4.3
 
 # Copy in the local repository to build from.
 COPY . /c13n

--- a/docker/readthedocs/Dockerfile
+++ b/docker/readthedocs/Dockerfile
@@ -1,11 +1,10 @@
 FROM golang:1.17-alpine as builder
 
-RUN apk add --no-cache --update alpine-sdk=1.0-r1 \
-    git=2.36.0-r0 \
-    make=4.3-r0 \
-    bash=5.1.16-r2 \
-    protobuf-dev=3.18.1-r2 \
-    protoc=3.18.1-r2
+RUN apk add --no-cache --update alpine-sdk~=1.0 \
+    make~=4.3 \
+    bash~=5.1.16 \
+    protobuf-dev~=3.18.1 \
+    protoc~=3.18.1
 
 RUN GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v1.4.3 \
  && GO111MODULE=on go get github.com/mwitkow/go-proto-validators/...@v0.3.0 \


### PR DESCRIPTION
Due to the release approach of alpine, package pinning should not be that strict. 

Resources

https://lifesaver.codes/answer/alpine-package-version-pinning-rule-too-strict-204
https://stschindler.medium.com/the-problem-with-docker-and-alpines-package-pinning-18346593e891